### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 ### Changelog
 
+#### Version 0.2.0
+
+- Handle faulty XML files with extra null byte
+- Handle encoded file names
+- Make Geometry3D comparable (Add_more_nodes)
+- Reformat with ruff
+- Add Capture MVR test file
+- Use ruff as a formatter, it's much faster and can configure line length
+- AUXData, Data, UserData
+- Parse GroupObject as a list
+- Add python 3.12 to tests
+
 #### Version 0.1.0
-* Initial release 
+
+- Initial release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 * generate wheel:
 
 ```bash
+python -m pip install setuptools wheel twine
 python3 setup.py sdist bdist_wheel
 ```
 * test upload to TestPypi with twine

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pymvr",
-    version="0.1.0",
+    version="0.2.0",
     long_description=long_description,
     description="My Virtual Rig library for Python",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#### Version 0.2.0

- Handle faulty XML files with extra null byte
- Handle encoded file names
- Make Geometry3D comparable (Add_more_nodes)
- Reformat with ruff
- Add Capture MVR test file
- Use ruff as a formatter, it's much faster and can configure line length
- AUXData, Data, UserData
- Parse GroupObject as a list
- Add python 3.12 to tests

